### PR TITLE
Fix bug in IsTimeValid method. Allowed minute 0.

### DIFF
--- a/nRFToolbox.Common/File.cs
+++ b/nRFToolbox.Common/File.cs
@@ -185,7 +185,7 @@ namespace Common.Utility
 				return isValid;
 			if (hour <= 0 || hour > 24)
 				return isValid;
-			if (minute <= 0 || minute > 59)
+			if (minute < 0 || minute > 59)
 				return isValid; 
 			isValid = true;
 			return isValid;


### PR DESCRIPTION
Hi,

There is small issue in the IsTimeValid method, the minute "0" causes IsValid = false result whereas it is still valid date time. Only for hours <= 0 is ok as 24 works for time 00:00.

Best Regards,
Przemek